### PR TITLE
Turned off the ril daemon

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -9,3 +9,17 @@ $(call inherit-product-if-exists, vendor/amazon/thor/thor-vendor.mk)
 # Device overlay
 DEVICE_PACKAGE_OVERLAYS += $(DEVICE_FOLDER)/overlay
 
+# Set dirty regions off
+PRODUCT_PROPERTY_OVERRIDES += \
+    hwui.render_dirty_regions=false
+
+# RIL turn off
+PRODUCT_PROPERTY_OVERRIDES += \
+    keyguard.no_require_sim=1 \
+    ro.radio.use-ppp=no \
+    ro.config.nocheckin=yes \
+    ro.radio.noril=yes
+
+# wifi-only device
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.carrier=wifi-only

--- a/full_thor.mk
+++ b/full_thor.mk
@@ -1,10 +1,6 @@
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/amazon/thor/device.mk)
 
-# wifi-only device
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.carrier=wifi-only
-
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
 
 PRODUCT_NAME := full_thor


### PR DESCRIPTION
If we turn off the ril daemon the cellular settings and icons are "removed"
